### PR TITLE
Add new game end state

### DIFF
--- a/strikefactor/gameplay/game_state_manager.py
+++ b/strikefactor/gameplay/game_state_manager.py
@@ -6,7 +6,7 @@ Manages state transitions and coordinates between different game states.
 from typing import Dict, Optional
 from .game_states import (
     GameState, MenuState, GameplayState, SummaryState, 
-    VisualizationState, ViewPitchesState
+    VisualizationState, ViewPitchesState, InningEndState
 )
 
 
@@ -29,7 +29,8 @@ class GameStateManager:
             'gameplay': GameplayState(self.game),
             'summary': SummaryState(self.game),
             'visualization': VisualizationState(self.game),
-            'view_pitches': ViewPitchesState(self.game)
+            'view_pitches': ViewPitchesState(self.game),
+            'inning_end': InningEndState(self.game)
         }
         
     def change_state(self, state_name: str):
@@ -81,6 +82,8 @@ class GameStateManager:
             self.change_state('visualization')
         elif menu_state_value == 'view_pitches':
             self.change_state('view_pitches')
+        elif menu_state_value == 'inning_end':
+            self.change_state('inning_end')
         elif isinstance(menu_state_value, str) and menu_state_value in ['Sale', 'Degrom', 'Yamamoto', 'Sasaki', 'Experimental']:
             self.change_state('gameplay')
         else:

--- a/strikefactor/gameplay/game_states.py
+++ b/strikefactor/gameplay/game_states.py
@@ -464,3 +464,49 @@ class ViewPitchesState(GameState):
                 screen, int(pitch_pos[0]), int(pitch_pos[1]), 
                 self.game.fourseamballsize, (255, 255, 255)
             )
+
+
+class InningEndState(GameState):
+    """State shown when inning ends (3 outs reached) - allows visualization before summary."""
+    
+    def __init__(self, game):
+        super().__init__(game)
+        
+    def enter(self):
+        """Initialize inning end state."""
+        self.game.ui_manager.set_button_visibility('inning_end')
+        # Keep current display showing the final pitch result
+        
+    def exit(self):
+        """Clean up inning end state."""
+        pass
+        
+    def update(self, time_delta: float):
+        """Update inning end logic."""
+        # No special update logic needed - just maintain display
+        pass
+        
+    def handle_event(self, event):
+        """Handle inning end events."""
+        self.game.ui_manager.process_events(event)
+        if event.type == pygame.QUIT:
+            return False
+        # Block pitching input (Q key) since inning is over
+        if event.type == pygame.KEYDOWN and event.key == pygame.K_q:
+            return True  # Consume the event without processing
+        return True
+        
+    def render(self, screen):
+        """Render the inning end state - same as gameplay but no new pitches allowed."""
+        screen.fill("black")
+        self.game.current_pitcher.draw_pitcher(0, 0)
+        self.game.field_renderer.draw_strikezone()
+        self.game.field_renderer.draw_field(self.game.scoreKeeper.get_bases())
+        self.game.batter.draw_stance(1)
+        
+        # Draw current ball position (final position)
+        if self.game.first_pitch_thrown:
+            pygame.gfxdraw.aacircle(
+                screen, int(self.game.ball[0]), int(self.game.ball[1]), 
+                self.game.fourseamballsize, (255, 255, 255)
+            )

--- a/strikefactor/main_refactored.py
+++ b/strikefactor/main_refactored.py
@@ -240,6 +240,7 @@ class Game:
         self.ui_manager.register_button_callback('visualise', lambda: self.set_menu_state('visualise'))
         self.ui_manager.register_button_callback('return_to_game', lambda: self.exit_view_pitches())
         self.ui_manager.register_button_callback('view_pitches', lambda: self.enter_view_pitches())
+        self.ui_manager.register_button_callback('continue_to_summary', lambda: self.continue_to_summary())
         
         # Game control callbacks
         self.ui_manager.register_button_callback('strikezone', lambda: self.field_renderer.toggle_strikezone_mode())
@@ -441,9 +442,15 @@ class Game:
     def exit_view_pitches(self):
         """Exit the view pitches mode."""
         self.ui_manager.hide_view_window()
-        self.ui_manager.set_button_visibility('in_game')
-        self.menu_state = self.current_gamemode
-        self.state_manager.change_state('gameplay')
+        # Return to the appropriate state based on inning status
+        if self.currentouts == 3 and self.inning_ended:
+            self.ui_manager.set_button_visibility('inning_end')
+            self.menu_state = 'inning_end'
+            self.state_manager.change_state('inning_end')
+        else:
+            self.ui_manager.set_button_visibility('in_game')
+            self.menu_state = self.current_gamemode
+            self.state_manager.change_state('gameplay')
         
     def enter_view_pitches(self):
         """Enter the view pitches mode."""
@@ -476,8 +483,13 @@ class Game:
         """Check if the inning should end."""
         if self.currentouts == 3 and not self.inning_ended:
             self.inning_ended = True
-            self.menu_state = 100
-            self.state_manager.change_state('summary')
+            self.menu_state = 'inning_end'
+            self.state_manager.change_state('inning_end')
+            
+    def continue_to_summary(self):
+        """Continue from inning end to summary state."""
+        self.menu_state = 100
+        self.state_manager.change_state('summary')
             
     def run(self):
         """Main game loop."""

--- a/strikefactor/ui/ui_manager.py
+++ b/strikefactor/ui/ui_manager.py
@@ -97,7 +97,12 @@ class UIManager:
             # Button for summary screen
             'back_to_main_menu': pygame_gui.elements.UIButton(
                 relative_rect=pygame.Rect((540, 530), (200, 50)),
-                text='MAIN MENU', manager=manager)
+                text='MAIN MENU', manager=manager),
+                
+            # Button for inning end screen
+            'continue_to_summary': pygame_gui.elements.UIButton(
+                relative_rect=pygame.Rect((540, 630), (200, 50)),
+                text='CONTINUE', manager=manager)
         }
         return buttons
 
@@ -250,6 +255,14 @@ class UIManager:
             self.banner.hide()
             self.scoreboard.hide()
             self.pitch_result.hide()
+        elif state == 'inning_end':
+            self.buttons['continue_to_summary'].show()
+            self.buttons['visualise'].show()
+            self.buttons['view_pitches'].show()
+            self.buttons['strikezone'].show()
+            self.buttons['main_menu'].show()
+            self.scoreboard.show()
+            self.pitch_result.show()
 
     def draw_typing_effect(self, message, counter, speed, position, use_big_font=False):
         """Draws text with a typing effect at the given position."""


### PR DESCRIPTION
Instead of immediately going to the summary screen after the third out, now the player can remain in the game mode and use the visualization settings but cannot continue to the next pitch. There is a continue button to return to the summary screen.